### PR TITLE
fix use of setLogLevel, deduplicate getSafe

### DIFF
--- a/enforce-rules.js
+++ b/enforce-rules.js
@@ -1,20 +1,14 @@
-const {setLogLevel, logExpression} = require('@cisl/zepto-logger');
+const {logExpression} = require('@cisl/zepto-logger');
+const {getSafe} = require('./utils');
+
 // logExpression is like console.log, but it also
 //   * outputs a timestamp
 //   * first argument takes text or JSON and handles it appropriately
 //   * second numeric argument establishes the logging priority: 1: high, 2: moderate, 3: low
-//   * logging priority n is set by -level n option on command line when agent-jok is started
-
-let logLevel = 2; // default log level
-setLogLevel(logLevel);
-
-const getSafe = (p, o, d) =>
-  p.reduce((xs, x) => (xs && xs[x] != null && xs[x] != undefined) ? xs[x] : d, o);
-
+//   * logging priority n is set by --level n option on command line when agent-jok is started
 
 function isSpeakerBot(message) {
-   if(message.speaker == "Human") return false;
-   else return true;
+  return message.speaker !== "Human";
 }
 
 function rule0Evaluation(message, queue) {

--- a/environment-orchestrator.js
+++ b/environment-orchestrator.js
@@ -13,6 +13,7 @@ const bodyParser = require('body-parser');
 const argv = require('minimist')(process.argv.slice(2));
 
 const {allowMessage} = require('./enforce-rules');
+const {getSafe} = require('./utils');
 
 let myPort = argv.port || appSettings.defaultPort || 14010;
 let logLevel = 1;
@@ -52,8 +53,6 @@ app.set('view engine', 'pug');
 app.use(methodOverride());
 app.use(express.static(path.join(__dirname, 'public')));
 
-const getSafe = (p, o, d) =>
-  p.reduce((xs, x) => (xs && xs[x] != null && xs[x] != undefined) ? xs[x] : d, o);
 
 function wait(ms) {
   let timeout, prom;

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,3 @@
+module.exports.getSafe = (p, o, d) => {
+  return p.reduce((xs, x) => (xs && xs[x] != null && xs[x] != undefined) ? xs[x] : d, o);
+};


### PR DESCRIPTION
Calling `setLogLevel(2)` in `./enforce-rules.js` is meaningless as it'll get overwritten by the call to it in the `./environment-orchestrator.js` once it parses command-line arguments.

Also moves `getSafe()` to a utils.js file so that we do not have two definitions of it in the project.